### PR TITLE
Fix incorrect params in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run
 ---
 
 ```
-route53-backup-to-s3 --config ./aws-credentials.json --s3Bucket your-bucket --s3Folder your-folder
+route53-backup-to-s3 --config ./aws-credentials.json --s3bucket your-bucket --s3folder your-folder
 ```
 
 Multi Credentials
@@ -34,7 +34,7 @@ Multi Credentials
 If you need to separate your Route53 and S3 credentials use the `--r53config` and `--s3config` flags.
 
 ```
-route53-backup-to-s3 --r53config ./r53-credentials.json --s3config ./s3-credentials.json --s3Bucket your-bucket --s3Folder your-folder
+route53-backup-to-s3 --r53config ./r53-credentials.json --s3config ./s3-credentials.json --s3bucket your-bucket --s3Folder your-folder
 ```
 
 Proxy
@@ -43,5 +43,5 @@ If you have the `https_proxy` environment variable set, the AWS API calls will g
 
 If you want to specify another proxy use the `--proxy` flag.
 ```
-route53-backup-to-s3 --config ./aws-credentials.json --s3Bucket s3://your-bucket/your-folder --proxy http://proxy.example.com:3128/
+route53-backup-to-s3 --config ./aws-credentials.json --s3bucket s3://your-bucket/your-folder --proxy http://proxy.example.com:3128/
 ```


### PR DESCRIPTION
Parameters are lower cased in the actual script, these aren't accepted by the script.
